### PR TITLE
- Add jestTimeout to Bindings

### DIFF
--- a/fable/Bindings.fs
+++ b/fable/Bindings.fs
@@ -151,6 +151,7 @@ type [<AllowNullLiteral>] JestStatic =
   abstract isMockFunction: ('A -> 'B) -> bool
   abstract genMockFromModule: string -> 'A
   abstract spyOn: 'A -> string -> Mock<_>
+  abstract setTimeout: int -> unit
 
 type [<AllowNullLiteral>] Mock<'A> =
   abstract calls: 'A []


### PR DESCRIPTION
Some of our tests will take more than 5 seconds to run. We should be able to adjust the timeout for those tests.
- Add jestTimeout to Bindings